### PR TITLE
Works with databases containing "_"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var parts = /^E11000 duplicate key error index: (?:[a-z-]+\.)+\$([a-z]+)/;
+var parts = /^E11000 duplicate key error index: (?:[a-z-_]+\.)+\$([a-z]+)/;
 
 function parse (err) {
   var matches = err && err.message.match(parts);


### PR DESCRIPTION
The current implementation did not work with my database, as it is named "megatherium_projectname". This small change makes the module work with database names containing underscores.

One could also add numbers to the allowed characters, but I'm actually not quite sure if numbers are allowed in MongoDB-names.