### PR TITLE
NodeJS 4.3.2 LTS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 'use strict';
 
-var parts = /E11000 duplicate key error index: (?:[a-z-_]+\.)+\$_?([a-z]+)/;
+var parts = /^E11000 duplicate key error (index|collection): (?:[a-z-.]+\.)+([a-z]*) index\: ([a-z]+)_([0-9]+)/;
 
 function parse (err) {
   var matches = err && err.message.match(parts);
   if (matches) {
-    return { code: 11000, path: matches[1] };
+    return { code: 11000, path: matches[3] };
+  } else {
+        var matches = err && err.message.match(/E11000 duplicate key error index: (?:[a-z-_]+\.)+\$_?([a-z]+)/);
+        if (matches) {return {code: 11000, path: matches[1]}; }
   }
   return err;
 }

--- a/test.js
+++ b/test.js
@@ -7,3 +7,4 @@ console.log(parse({ message: 'something else entirely' }));
 console.log(parse({ message: 'E11000 duplicate key error index: stompflow.members.$email_1  dup key' }));
 console.log(parse({ message: 'insertDocument :: caused by :: 11000 E11000 duplicate key error index: pvn.users.$_email_1  dup key: { : "j@b.com" }' }));
 console.log(parse({ message: 'E11000 duplicate key error index: stompflow-test.members.$email_1  dup key' }));
+console.log(parse({message: 'E11000 duplicate key error collection: black-back-space.users index: username_1 dup key: { : "SargTeX" }'}));


### PR DESCRIPTION
We had another problem when using mongoose and mongoose-parse under node 4.3.2 (LTS).
The code that worked for 5.x didn't work here, as the error response from mongoose was in a different format, example:
`'E11000 duplicate key error collection: thedatabasename.users index: username_1 dup key: { : "theusername" }'`

The code above fixes this.
